### PR TITLE
Fixed models to use key 'live_mode' instead of 'livemode'

### DIFF
--- a/goSellSDK/Charge/Models/Charge.swift
+++ b/goSellSDK/Charge/Models/Charge.swift
@@ -170,7 +170,7 @@ import struct Foundation.NSURL.URL
         case descriptionText        = "description"
         case failureCode            = "failure_code"
         case failureMessage         = "failure_message"
-        case isLiveMode             = "livemode"
+        case isLiveMode             = "live_mode"
         case metadata               = "metadata"
         case isPaid                 = "paid"
         case receiptEmail           = "receipt_email"

--- a/goSellSDK/Customers/Models/Customer.swift
+++ b/goSellSDK/Customers/Models/Customer.swift
@@ -57,6 +57,6 @@
         case phone              = "phone"
         case metadata           = "metadata"
         case creationDate       = "created"
-        case isLiveMode         = "livemode"
+        case isLiveMode         = "live_mode"
     }
 }

--- a/goSellSDK/Token/Models/Token.swift
+++ b/goSellSDK/Token/Models/Token.swift
@@ -68,7 +68,7 @@ import class Foundation.NSObject.NSObject
         case type           = "type"
         case creationDate   = "created"
         case clientIP       = "client_ip"
-        case isLiveMode     = "livemode"
+        case isLiveMode     = "live_mode"
         case isUsed         = "used"
     }
 }


### PR DESCRIPTION
The current SDK version cannot parse the server json response because it is looking for key 'livemode' when the server is returning the key as 'live_mode'.